### PR TITLE
NLRFIM-130 - Store query parameters in session when redirecting to IdP

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## 3.0.2 (planned)
 - NLRFIM-124: ResponseLocation is optional cf. section 2.2.2 in OASIS SAML 2 Metadata and hence if attribute is not present NULL check must be performed.
+- NLRFIM-130: Store query parameters in session when redirecting to IdP.
 
 ## 3.0.1
 First official release based on OpenSAML 3.

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>oiosaml3-parent</artifactId>
         <groupId>dk.digst</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
 
     <build>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>dk.digst</groupId>
             <artifactId>oiosaml3.java</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>oiosaml3-parent</artifactId>
         <groupId>dk.digst</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/oiosaml/pom.xml
+++ b/oiosaml/pom.xml
@@ -6,14 +6,14 @@
 	<artifactId>oiosaml3.java</artifactId>
 	<name>OIOSAML for Java v3</name>
 	<packaging>jar</packaging>
-	<version>3.0.1</version>
+	<version>3.0.2-SNAPSHOT</version>
 	<description>SAML Servlet Filter, configured to work with the danish SAML profile OIOSAML 3.0.0</description>
 	<url>https://digitaliser.dk/group/42063/resources</url>
 
 	<parent>
 		<artifactId>oiosaml3-parent</artifactId>
 		<groupId>dk.digst</groupId>
-		<version>3.0.1</version>
+		<version>3.0.2-SNAPSHOT</version>
 	</parent>
 
 	<licenses>

--- a/oiosaml/src/main/java/dk/gov/oio/saml/filter/AuthenticatedFilter.java
+++ b/oiosaml/src/main/java/dk/gov/oio/saml/filter/AuthenticatedFilter.java
@@ -104,7 +104,12 @@ public class AuthenticatedFilter implements Filter {
 
                 AuthnRequestService authnRequestService = AuthnRequestService.getInstance();
 
-                req.getSession().setAttribute(Constants.SESSION_REQUESTED_PATH, req.getRequestURI());
+                String reqPath = req.getRequestURI();
+                if(req.getQueryString() != null) {
+                    reqPath += "?" + req.getQueryString();
+                }
+
+                req.getSession().setAttribute(Constants.SESSION_REQUESTED_PATH, reqPath);
                 MessageContext<SAMLObject> authnRequest = authnRequestService.createMessageWithAuthnRequest(isPassive, forceAuthn, requiredNsisLevel, attributeProfile);
                 sendAuthnRequest(req, res, authnRequest, requiredNsisLevel);
 			}

--- a/oiosaml/src/test/java/dk/gov/oio/saml/filter/AuthenticatedFilterTest.java
+++ b/oiosaml/src/test/java/dk/gov/oio/saml/filter/AuthenticatedFilterTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -334,6 +335,54 @@ public class AuthenticatedFilterTest {
 		// verify that the AuthnRequest is forceAuthn
 		Assertions.assertTrue(authnRequest.isPassive());
 		Assertions.assertFalse(authnRequest.isForceAuthn());
+	}
+
+	@DisplayName("Setting SESSION_REQUESTED_PATH when authenticating")
+	@Test
+	public void settingRedirectUrlOnAuthentication() throws Exception {
+		AuthenticatedFilter filter = new AuthenticatedFilter();
+		filter.init(getConfig(false, false, "SUBSTANTIAL"));
+
+		// mock session with state: not logged in at any NSIS level
+		HttpSession session = Mockito.mock(HttpSession.class);
+		Mockito.when(session.getAttribute(Constants.SESSION_NSIS_LEVEL)).thenReturn(null);
+		Mockito.when(session.getAttribute(Constants.SESSION_AUTHENTICATED)).thenReturn(null);
+
+		// mock request
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		Mockito.when(request.getSession()).thenReturn(session);
+		Mockito.when(request.getRequestURI()).thenReturn("/some/url");
+		Mockito.when(request.getQueryString()).thenReturn("var1=1&var2=2");
+
+		// invoke method to be tested
+		filter.doFilter(request, Mockito.mock(HttpServletResponse.class), Mockito.mock(FilterChain.class));
+
+		// verify that URL is added to the session
+		Mockito.verify(session, Mockito.times(1)).setAttribute(Constants.SESSION_REQUESTED_PATH,"/some/url?var1=1&var2=2");
+	}
+
+	@DisplayName("Not setting SESSION_REQUESTED_PATH on current session")
+	@Test
+	public void settingRedirectUrl() throws Exception {
+		AuthenticatedFilter filter = new AuthenticatedFilter();
+		filter.init(getConfig(false, false, "SUBSTANTIAL"));
+
+		// mock session with state: logged in at NSIS level SUBSTANTIAL
+		HttpSession session = Mockito.mock(HttpSession.class);
+		Mockito.when(session.getAttribute(Constants.SESSION_NSIS_LEVEL)).thenReturn(NSISLevel.SUBSTANTIAL);
+		Mockito.when(session.getAttribute(Constants.SESSION_AUTHENTICATED)).thenReturn("true");
+
+		// mock request
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		Mockito.when(request.getSession()).thenReturn(session);
+		Mockito.when(request.getRequestURI()).thenReturn("/some/url");
+		Mockito.when(request.getQueryString()).thenReturn("var1=1&var2=2");
+
+		// invoke method to be tested
+		filter.doFilter(request, Mockito.mock(HttpServletResponse.class), Mockito.mock(FilterChain.class));
+
+		// verify that URL is added to the session
+		Mockito.verify(session,Mockito.never()).setAttribute(Mockito.eq(Constants.SESSION_REQUESTED_PATH), Mockito.any());
 	}
 
 	private FilterConfig getConfig(boolean isPassive, boolean forceAuthn, String requiredLevel) {

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dk.digst</groupId>
 	<artifactId>oiosaml3-parent</artifactId>
-	<version>3.0.1</version>
+	<version>3.0.2-SNAPSHOT</version>
 	<name>OIOSAML v3 for Java</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
This implementation is the one suggested in the incident, but this could also be solved by setting responseLocation on the  SingleSignOnService endpoint on the auth request...