### PR TITLE
log4j2 dependency security upgrade

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The fix for CVE-2021-44228 provided by log4j2 did not completely solve the issue.
We must upgrade to 2.16.0 to mitigate the issue (CVE-2021-45046)