### PR TITLE
Updated log4j2 dependency

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Updated the log4j2 dependency to mitigate new vulnerability CVE-2021-44832

(cherry picked from commit ded6fd96b542443b342d49a4afc31b983aa45257)