### PR TITLE
REF-8: Fix seconds/milliseconds mixup in in-memory session cleanup (issue #76)

### DIFF
--- a/oiosaml/src/main/java/dk/gov/oio/saml/session/SessionCleanerTask.java
+++ b/oiosaml/src/main/java/dk/gov/oio/saml/session/SessionCleanerTask.java
@@ -20,7 +20,7 @@ public class SessionCleanerTask implements Runnable {
 
     @Override
     public void run() {
-        log.debug("Cleaning session data, time: {}, timeout: {}", System.currentTimeMillis(), maxInactiveIntervalSeconds * 1000);
+        log.debug("Cleaning session data, time: {}, timeout (seconds): {}", System.currentTimeMillis(), maxInactiveIntervalSeconds);
         try {
             SessionHandler sessionHandler = OIOSAML3Service.getSessionHandlerFactory().getHandler();
             sessionHandler.cleanup(maxInactiveIntervalSeconds);

--- a/oiosaml/src/main/java/dk/gov/oio/saml/session/SessionHandler.java
+++ b/oiosaml/src/main/java/dk/gov/oio/saml/session/SessionHandler.java
@@ -134,7 +134,7 @@ public interface SessionHandler {
     /**
      * Clean stored ids and sessions.
      *
-     * @param maxInactiveIntervalSeconds Milliseconds to store session, before it should be invalidated.
+     * @param maxInactiveIntervalSeconds Seconds to store session, before it should be invalidated.
      */
     void cleanup(long maxInactiveIntervalSeconds);
 }

--- a/oiosaml/src/main/java/dk/gov/oio/saml/session/database/DatabaseSessionHandler.java
+++ b/oiosaml/src/main/java/dk/gov/oio/saml/session/database/DatabaseSessionHandler.java
@@ -351,7 +351,7 @@ public class DatabaseSessionHandler implements SessionHandler {
     /**
      * Clean stored ids and sessions.
      *
-     * @param maxInactiveIntervalSeconds Milliseconds to store session, before it should be invalidated.
+     * @param maxInactiveIntervalSeconds Seconds to store session, before it should be invalidated.
      */
     @Override
     public void cleanup(final long maxInactiveIntervalSeconds) {

--- a/oiosaml/src/main/java/dk/gov/oio/saml/session/inmemory/InMemorySessionHandler.java
+++ b/oiosaml/src/main/java/dk/gov/oio/saml/session/inmemory/InMemorySessionHandler.java
@@ -252,18 +252,23 @@ public class InMemorySessionHandler implements SessionHandler {
     /**
      * Clean stored ids and sessions.
      *
-     * @param maxInactiveIntervalSeconds Milliseconds to store session, before it should be invalidated.
+     * @param maxInactiveIntervalSeconds Seconds to store session, before it should be invalidated.
      */
     @Override
     public void cleanup(long maxInactiveIntervalSeconds) {
+        // TimeOutWrapper.isExpired() compares against System.currentTimeMillis(), so the timeout
+        // must be in milliseconds. The interval is supplied in seconds (see SessionHandler#cleanup),
+        // so convert before comparing - otherwise sessions expire 1000x too early (issue #76).
+        long maxInactiveIntervalMillis = maxInactiveIntervalSeconds * 1000L;
+
         // Trim usedAssertionIds to size with sessionHandlerNumTrackedSessionIds
         while (!usedAssertionIds.isEmpty() && usedAssertionIds.size() > sessionHandlerNumTrackedSessionIds) {
             usedAssertionIds.remove(usedAssertionIds.pollFirst());
         }
-        cleanup(sessionIndexMap, maxInactiveIntervalSeconds, "SessionIndexMap");
-        cleanup(assertions, maxInactiveIntervalSeconds, "Assertions");
-        cleanup(authnRequests, maxInactiveIntervalSeconds, "AuthnRequests");
-        cleanup(logoutRequests, maxInactiveIntervalSeconds, "LogoutRequests");
+        cleanup(sessionIndexMap, maxInactiveIntervalMillis, "SessionIndexMap");
+        cleanup(assertions, maxInactiveIntervalMillis, "Assertions");
+        cleanup(authnRequests, maxInactiveIntervalMillis, "AuthnRequests");
+        cleanup(logoutRequests, maxInactiveIntervalMillis, "LogoutRequests");
     }
 
     private <E, T> void cleanup(Map<E, TimeOutWrapper<T>> map, long cleanupDelay, String msg) {

--- a/oiosaml/src/test/java/dk/gov/oio/saml/session/inmemory/InMemorySessionHandlerTest.java
+++ b/oiosaml/src/test/java/dk/gov/oio/saml/session/inmemory/InMemorySessionHandlerTest.java
@@ -152,6 +152,23 @@ class InMemorySessionHandlerTest {
         Assertions.assertNull(assertionWrapperOutput);
     }
 
+    @DisplayName("Test that stored Assertion survives until its timeout (seconds, not millis) - issue #76")
+    @Test
+    void testStoreAssertionNotRemovedBeforeTimeout() throws Exception {
+        AssertionWrapper assertionWrapperInput = new AssertionWrapper(createAssertion());
+
+        sessionHandler.storeAssertion(session, assertionWrapperInput);
+
+        // Wait far longer than the timeout-interpreted-as-milliseconds (the #76 bug: 5s -> 5ms),
+        // but far less than the real 5 second timeout. The assertion must still be present.
+        Thread.sleep(100);
+        sessionHandler.cleanup(5); // 5 seconds
+
+        AssertionWrapper assertionWrapperOutput = sessionHandler.getAssertion(session);
+        Assertions.assertNotNull(assertionWrapperOutput,
+                "Assertion must survive cleanup until its timeout elapses (timeout is in seconds, not milliseconds)");
+    }
+
     @DisplayName("Test that stored Assertion is removed after timeout and can not be retrieved using session index")
     @Test
     void testStoreAssertionTimeoutSessionIndex() throws Exception {


### PR DESCRIPTION
Fixes #76

## Summary

On the in-memory session handler, sessions expired ~1000x too early — a 30-minute timeout became 1.8 seconds — logging users out on almost every cleanup run. The database session handler was not affected.

Root cause: `SessionHandler.cleanup(long maxInactiveIntervalSeconds)` takes the timeout in **seconds** (as the `DatabaseSessionHandler` and the caller, which reads `HttpSession.getMaxInactiveInterval()`, both treat it). But `InMemorySessionHandler.cleanup()` passed that seconds value straight to `TimeOutWrapper.isExpired(delay)`, which compares against `System.currentTimeMillis()` and therefore expects **milliseconds**.

## Fix

- `InMemorySessionHandler.cleanup()` — convert seconds → milliseconds before the expiry comparison.
- `SessionCleanerTask` — fix the debug log that printed the timeout inconsistently (`* 1000`).
- Correct the misleading "Milliseconds" javadoc on the `cleanup` contract (`SessionHandler`) and both implementations — the parameter is seconds.

## Test

Adds an `InMemorySessionHandlerTest` regression test that stores an assertion, waits well past the buggy milliseconds interpretation but far short of the real seconds timeout, and asserts the assertion is still present. Full suite: `Tests run: 108, Failures: 0, Errors: 0`.

## Attribution

Ports the fix from the Trifork fork (Jeppe Sommer, commits `6485c2b` and `bc7b004`), and adds the regression test those commits lacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)