### PR TITLE
REF-15: Fix transposed default audit attribute sources for SESSION_ID and USER

### DIFF
--- a/oiosaml/src/main/java/dk/gov/oio/saml/config/Configuration.java
+++ b/oiosaml/src/main/java/dk/gov/oio/saml/config/Configuration.java
@@ -515,8 +515,8 @@ public class Configuration {
             configuration.auditLoggerClassName = StringUtil.defaultIfEmpty(this.auditLoggerClassName, "dk.gov.oio.saml.audit.Slf4JAuditLogger");
             configuration.auditRequestAttributeIP = StringUtil.defaultIfEmpty(this.auditRequestAttributeIP, "request:remoteAddr");
             configuration.auditRequestAttributePort = StringUtil.defaultIfEmpty(this.auditRequestAttributePort, "request:remotePort");
-            configuration.auditRequestAttributeSessionId = StringUtil.defaultIfEmpty(this.auditRequestAttributeSessionId, "request:remoteUser");
-            configuration.auditRequestAttributeServiceProviderUserId = StringUtil.defaultIfEmpty(this.auditRequestAttributeServiceProviderUserId, "request:sessionId");
+            configuration.auditRequestAttributeSessionId = StringUtil.defaultIfEmpty(this.auditRequestAttributeSessionId, "request:sessionId");
+            configuration.auditRequestAttributeServiceProviderUserId = StringUtil.defaultIfEmpty(this.auditRequestAttributeServiceProviderUserId, "request:remoteUser");
             configuration.sessionHandlerFactoryClassName = StringUtil.defaultIfEmpty(this.sessionHandlerFactoryClassName, null);
             configuration.sessionHandlerJndiName = StringUtil.defaultIfEmpty(this.sessionHandlerJndiName, null);
             configuration.sessionHandlerJdbcUrl = StringUtil.defaultIfEmpty(this.sessionHandlerJdbcUrl, null);

--- a/oiosaml/src/test/java/dk/gov/oio/saml/TestSuite.java
+++ b/oiosaml/src/test/java/dk/gov/oio/saml/TestSuite.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(JUnitPlatform.class)
 @SelectPackages( {
+    "dk.gov.oio.saml.config",
     "dk.gov.oio.saml.filter",
     "dk.gov.oio.saml.oiobpp",
     "dk.gov.oio.saml.service",

--- a/oiosaml/src/test/java/dk/gov/oio/saml/config/ConfigurationTest.java
+++ b/oiosaml/src/test/java/dk/gov/oio/saml/config/ConfigurationTest.java
@@ -1,0 +1,36 @@
+package dk.gov.oio.saml.config;
+
+import dk.gov.oio.saml.util.InternalException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationTest {
+
+    private Configuration minimalConfiguration() throws InternalException {
+        // Only the mandatory fields are supplied; every optional value falls back to its default.
+        return new Configuration.Builder()
+                .setSpEntityID("https://sp.example.com")
+                .setBaseUrl("https://sp.example.com")
+                .setIdpEntityID("https://idp.example.com")
+                .setIdpMetadataUrl("https://idp.example.com/metadata")
+                .setKeystoreLocation("keystore.p12")
+                .setKeystorePassword("password")
+                .setKeyAlias("alias")
+                .build();
+    }
+
+    @DisplayName("Default audit request attributes map to the matching request value (REF-15, issue #76 sibling)")
+    @Test
+    void testDefaultAuditRequestAttributes() throws InternalException {
+        Configuration configuration = minimalConfiguration();
+
+        // The SessionId audit field must default to the session id and the ServiceProviderUserId
+        // audit field to the remote user - these two defaults were previously transposed, so the
+        // SESSION_ID column logged the user and the USER column logged the session id.
+        Assertions.assertEquals("request:sessionId", configuration.getAuditRequestAttributeSessionId());
+        Assertions.assertEquals("request:remoteUser", configuration.getAuditRequestAttributeServiceProviderUserId());
+        Assertions.assertEquals("request:remoteAddr", configuration.getAuditRequestAttributeIP());
+        Assertions.assertEquals("request:remotePort", configuration.getAuditRequestAttributePort());
+    }
+}


### PR DESCRIPTION
The default lookup specs for the `SessionId` and `ServiceProviderUserId` audit attributes were swapped in `Configuration.Builder.build()`:

- `auditRequestAttributeSessionId` defaulted to `request:remoteUser`
- `auditRequestAttributeServiceProviderUserId` defaulted to `request:sessionId`

`AuditRequestUtil` resolves these specs literally (`request:sessionId` → session id, `request:remoteUser` → remote user), so with the default configuration the audit log's **`SESSION_ID` column was populated with the remote user** and the **`USER` column with the session id**. Nothing downstream compensated — the emitted audit records were genuinely wrong.

## Fix
- Swap the two defaults so each audit column is sourced correctly. This also matches the documented defaults.

## Tests
- Add `ConfigurationTest` asserting the default audit attribute values (fails against the old transposed defaults, passes with the fix).
- Register the previously-untested `dk.gov.oio.saml.config` package in `TestSuite` so the new test actually runs.

Discovered during the REF-14 documentation review (#88).

Note: two unrelated tests (`OIOBPPUtilTest`, `CRLCheckerTest`) fail in the local environment on `master` as well — JDK 26 JAXB and live-network OCSP respectively — and are not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)